### PR TITLE
build: adjust minimum required package of illuminate/queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.0",
         "aws/aws-sdk-php": "^3.239.9",
-        "illuminate/queue": "^10.44.0"
+        "illuminate/queue": "^10.43.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Downgrade minimum version of `illuminate/queue` from `10.44.0` to `10.43.0`